### PR TITLE
Reworks scaffold logic

### DIFF
--- a/.lagoon/Dockerfile
+++ b/.lagoon/Dockerfile
@@ -1,16 +1,16 @@
 FROM uselagoon/php-8.4-cli-drupal:latest AS cli
 
+# set up scaffolding for drupal-cms
+COPY .lagoon/scripts/scaffold.sh /lagoon/entrypoints/999-drupal-cms-scaffold.sh
+
 COPY composer.* /app/
 COPY assets /app/assets
 COPY .lagoon /app/.lagoon
-RUN composer install --no-dev \
-    && cp -r /app/vendor/drupal/cms/web/profiles/drupal_cms_installer /app/web/profiles/
+
+# Let the scaffolding file take care of running the install for us.
+RUN /lagoon/entrypoints/999-drupal-cms-scaffold.sh
 RUN mkdir -p -v -m775 /app/web/sites/default/
 
-# set up scaffolding for drupal-cms
-
-COPY .lagoon/scripts/scaffold.sh /lagoon/entrypoints/999-drupal-cms-scaffold.sh
-RUN /lagoon/entrypoints/999-drupal-cms-scaffold.sh
 
 # Define where the Drupal Root is located
 ENV WEBROOT=web

--- a/.lagoon/scripts/scaffold.sh
+++ b/.lagoon/scripts/scaffold.sh
@@ -8,6 +8,10 @@ cd /app
 if [ ! -f "$FLAG_FILE" ]; then
     echo "*** NO SCAFFOLD FILE FOUND ***"
     git config --global --add safe.directory /app
+
+    # We run composer install again here, knowing full well that it mightn't need to run
+    # Worst case this slightly slows down the build, but it won't be by much.
+
     composer install --no-dev
     cp -r /app/vendor/drupal/cms/web/profiles/drupal_cms_installer /app/web/profiles/
     # Create the flag file to indicate the script has run
@@ -19,7 +23,7 @@ else
 fi
 
 # We attempt to copy the configuration settings into the appropriate location
-
+# This may run in several circumstances, locally,
 if [ ! -f "/app/web/sites/default/settings.php" ]; then
     # First, we copy in the default settings from the composer installed drupal_integrations
     cp /app/drush/Commands/contrib/drupal_integrations/assets/* /app/web/sites/default

--- a/.lagoon/scripts/scaffold.sh
+++ b/.lagoon/scripts/scaffold.sh
@@ -8,10 +8,6 @@ cd /app
 if [ ! -f "$FLAG_FILE" ]; then
     echo "*** NO SCAFFOLD FILE FOUND ***"
     git config --global --add safe.directory /app
-
-    # We run composer install again here, knowing full well that it mightn't need to run
-    # Worst case this slightly slows down the build, but it won't be by much.
-
     composer install --no-dev
     cp -r /app/vendor/drupal/cms/web/profiles/drupal_cms_installer /app/web/profiles/
     # Create the flag file to indicate the script has run

--- a/.lagoon/scripts/scaffold.sh
+++ b/.lagoon/scripts/scaffold.sh
@@ -8,12 +8,8 @@ cd /app
 if [ ! -f "$FLAG_FILE" ]; then
     echo "*** NO SCAFFOLD FILE FOUND ***"
     git config --global --add safe.directory /app
-    if [ -z "$LAGOON_KUBERNETES" ]; then
-        echo "Not running in Lagoon - we will try install"
-        composer install --no-dev
-        cp -r /app/vendor/drupal/cms/web/profiles/drupal_cms_installer /app/web/profiles/
-        cp /app/drush/Commands/contrib/drupal_integrations/assets/* /app/web/sites/default
-    fi    
+    composer install --no-dev
+    cp -r /app/vendor/drupal/cms/web/profiles/drupal_cms_installer /app/web/profiles/
     # Create the flag file to indicate the script has run
     echo "About to create $FLAG_FILE"
     touch "$FLAG_FILE"
@@ -22,8 +18,13 @@ else
     echo "The initialization script has already run."
 fi
 
-# here we attempt to copy the details
+# We attempt to copy the configuration settings into the appropriate location
+
 if [ ! -f "/app/web/sites/default/settings.php" ]; then
+    # First, we copy in the default settings from the composer installed drupal_integrations
+    cp /app/drush/Commands/contrib/drupal_integrations/assets/* /app/web/sites/default
+    # Second, we move over anything from our assets that we may want to use to override/supplement the defaults
     cp /app/.lagoon/assets/* /app/web/sites/default
+    # Finally, we enable the lagoon settings for the site
     mv /app/web/sites/default/initial.settings.php /app/web/sites/default/settings.php
 fi


### PR DESCRIPTION
This PR removes an extraneous check for the LAGOON_KUBERNETES env var (it was being used for DB installation logic before) and moves site configuration asset copying into a more logically consistent place